### PR TITLE
Fix static file serving

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,16 +1,34 @@
 var http = require('http');
 var fs = require('fs');
+var path = require('path');
 
 const PORT = 8080;
 
-fs.readFile('./index.html', function(err, html) {
-  if (err) throw err;
+http
+	.createServer(function(request, response) {
+		var filePath = '.' + request.url;
+		if (filePath == './') {
+			filePath = './index.html';
+		}
 
-  http
-    .createServer(function(request, response) {
-      response.writeHeader(200, { 'Content-Type': 'text/html' });
-      response.write(html);
-      response.end();
-    })
-    .listen(PORT);
-});
+		var extname = String(path.extname(filePath)).toLowerCase();
+		var mimeTypes = {
+			'.html': 'text/html',
+			'.js': 'text/javascript',
+			'.css': 'text/css',
+			'.wasm': 'application/wasm'
+		};
+
+		var contentType = mimeTypes[extname] || 'application/octet-stream';
+
+		fs.readFile(filePath, function(error, content) {
+			if (error) {
+				response.writeHead(404);
+				response.end('404 Not Found');
+			} else {
+				response.writeHead(200, { 'Content-Type': contentType });
+				response.end(content, 'utf-8');
+			}
+		});
+	})
+	.listen(PORT);


### PR DESCRIPTION
Previously, `index.html`'s content were always served regardless of the request path. This code is adapted from [here](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Node_server_without_framework).